### PR TITLE
PRO-2187 PRO-2189 Export the things!

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,9 @@ module.exports = {
     return {
       post: {
         export (req) {
+          if (!Array.isArray(req.body._ids)) {
+            throw self.apos.error('invalid');
+          }
           const extension = self.apos.launder.string(req.body.extension);
           const batchSize = self.apos.launder.integer(req.body.batchSize);
           const expiration = typeof self.options.export === 'object' ? self.apos.launder.integer(self.options.export.expiration) : null;
@@ -44,6 +47,10 @@ module.exports = {
           if (!self.exportFormats[extension]) {
             throw self.apos.error('invalid');
           }
+
+          // Add the piece type label to req.body for notifications.
+          req.body.type = req.body._ids.length === 1 ? self.options.label : self.options.pluralLabel;
+          // TODO: work out how to make these sentence cased properly
 
           const format = self.exportFormats[extension];
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,29 @@ const fs = require('fs');
 
 module.exports = {
   improve: '@apostrophecms/piece-type',
+  batchOperations (self) {
+    return {
+      add: {
+        export: {
+          label: 'Export',
+          route: '/export',
+          messages: {
+            progress: 'Exported {{ count }} {{ type }}.',
+            completed: 'Exporting {{ type }}...'
+          },
+          requestOptions: {
+            extension: 'csv'
+          }
+        }
+      },
+      group: {
+        more: {
+          icon: 'dots-vertical-icon',
+          operations: [ 'export' ]
+        }
+      }
+    };
+  },
   init (self) {
     self.exportFormats = {
       csv: {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
           label: 'Export',
           route: '/export',
           messages: {
-            progress: 'Exported {{ count }} {{ type }}.',
+            progress: 'Exporting complete.',
             completed: 'Exporting {{ type }}...'
           },
           requestOptions: {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ module.exports = {
 
           // Add the piece type label to req.body for notifications.
           req.body.type = req.body._ids.length === 1 ? self.options.label : self.options.pluralLabel;
-          // TODO: work out how to make these sentence cased properly
 
           const format = self.exportFormats[extension];
 

--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@ module.exports = {
           if (!Array.isArray(req.body._ids)) {
             throw self.apos.error('invalid');
           }
+          // Reassigning this since it is referenced off of req elsewhere.
+          req.body._ids = self.apos.launder.ids(req.body._ids);
+
           const extension = self.apos.launder.string(req.body.extension);
           const batchSize = self.apos.launder.integer(req.body.batchSize);
           const expiration = typeof self.options.export === 'object' ? self.apos.launder.integer(self.options.export.expiration) : null;

--- a/lib/export.js
+++ b/lib/export.js
@@ -207,8 +207,5 @@ module.exports = (self) => {
     beforeExport (req, piece, record) {
       return record;
     }
-    // updateProgress() {
-
-    // }
   };
 };

--- a/lib/export.js
+++ b/lib/export.js
@@ -10,11 +10,21 @@ module.exports = (self) => {
         self.apos.util.error(e);
       }
     },
-    async writeBatch (req, out, lastId = '', reporting, options) {
+    async writeBatch (req, out, _ids, lastId = '', reporting, options) {
       let batch;
+
       try {
-        batch = await self.find(req)
-          .sort({ _id: 1 }).and({ _id: { $gt: lastId } })
+        batch = await self.find(req, {
+          $and: [
+            {
+              _id: { $gt: lastId }
+            },
+            {
+              _id: { $in: _ids }
+            }
+          ]
+        })
+          .sort({ _id: 1 })
           .limit(options.batchSize || 100).toArray();
       } catch (error) {
         // TODO: Probably deliver the error value differently.
@@ -133,9 +143,11 @@ module.exports = (self) => {
       });
 
       let lastId = '';
+      const _ids = req.body._ids.map(id => id.replace(':draft', ':published'));
+      const pubReq = req.clone({ mode: 'published' });
 
       do {
-        lastId = await self.writeBatch(req, out, lastId, reporting, {
+        lastId = await self.writeBatch(pubReq, out, _ids, lastId, reporting, {
           ...options
         });
       } while (lastId);
@@ -193,5 +205,8 @@ module.exports = (self) => {
     beforeExport (req, piece, record) {
       return record;
     }
+    // updateProgress() {
+
+    // }
   };
 };

--- a/lib/export.js
+++ b/lib/export.js
@@ -52,6 +52,8 @@ module.exports = (self) => {
       return lastId;
     },
     async exportRun (req, reporting, options) {
+      reporting.setTotal(req.body._ids.length);
+
       const extension = options.extension;
       const format = options.format;
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -52,7 +52,9 @@ module.exports = (self) => {
       return lastId;
     },
     async exportRun (req, reporting, options) {
-      reporting.setTotal(req.body._ids.length);
+      if (typeof reporting.setTotal === 'function') {
+        reporting.setTotal(req.body._ids.length);
+      }
 
       const extension = options.extension;
       const format = options.format;

--- a/lib/export.js
+++ b/lib/export.js
@@ -27,8 +27,8 @@ module.exports = (self) => {
           .sort({ _id: 1 })
           .limit(options.batchSize || 100).toArray();
       } catch (error) {
-        // TODO: Probably deliver the error value differently.
-        throw self.apos.error('error', error);
+        self.apos.util.error(error);
+        throw self.apos.error('notfound');
       }
 
       if (!batch.length) {
@@ -101,8 +101,9 @@ module.exports = (self) => {
           if (!reported) {
             reported = true;
             self.cleanup(filepath);
-            // TODO: Probably deliver the error value differently.
-            return reject(self.apos.error('error', err));
+            self.apos.util.error(err);
+
+            return reject(self.apos.error('error'));
           }
         });
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {
-    "apostrophe": "github:apostrophecms/apostrophe#feature/batch-operations",
+    "apostrophe": "https://github.com/apostrophecms/apostrophe.git#feature/batch-operations",
     "eslint": "^7.9.0",
     "eslint-config-apostrophe": "^3.4.0",
     "eslint-config-standard": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {
-    "apostrophe": "https://github.com/apostrophecms/apostrophe.git#feature/batch-operations",
+    "apostrophe": "apostrophecms/apostrophe#feature/batch-operations",
     "eslint": "^7.9.0",
     "eslint-config-apostrophe": "^3.4.0",
     "eslint-config-standard": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {
-    "apostrophe": "^3.6.0",
+    "apostrophe": "github:apostrophecms/apostrophe#feature/batch-operations",
     "eslint": "^7.9.0",
     "eslint-config-apostrophe": "^3.4.0",
     "eslint-config-standard": "^14.1.1",

--- a/test/test.js
+++ b/test/test.js
@@ -97,6 +97,7 @@ describe('Pieces Exporter', function () {
   });
 
   const richText = '<h2>This is rich text.</h2>';
+  let _ids1 = [];
 
   it('can insert many test articles', async function () {
     const req = apos.task.getReq();
@@ -121,6 +122,7 @@ describe('Pieces Exporter', function () {
     }
 
     const inserted = await Promise.all(promises);
+    _ids1 = inserted.map(doc => doc._id);
 
     assert(inserted.length === 50);
     assert(!!inserted[0]._id);
@@ -128,6 +130,9 @@ describe('Pieces Exporter', function () {
 
   it('can export the articles as a CSV', async function () {
     const req = apos.task.getReq();
+    req.body = req.body || {};
+    req.body._ids = _ids1;
+
     let good = 0;
     let bad = 0;
     let results;
@@ -172,7 +177,7 @@ describe('Pieces Exporter', function () {
   const plainText = 'This is plain text.';
   const plainTextWrapped = `<p>${plainText}</p>`;
   const secret = 'hide-me';
-
+  let _ids2 = [];
   it('can insert many test products', async function () {
     const req = apos.task.getReq();
 
@@ -197,6 +202,7 @@ describe('Pieces Exporter', function () {
     }
 
     const inserted = await Promise.all(promises);
+    _ids2 = inserted.map(doc => doc._id);
 
     assert(inserted.length === 30);
     assert(!!inserted[0]._id);
@@ -206,6 +212,9 @@ describe('Pieces Exporter', function () {
 
   it('can export the products as a CSV', async function () {
     const req = apos.task.getReq();
+    req.body = req.body || {};
+    req.body._ids = _ids2;
+
     let good = 0;
     let bad = 0;
     let results;
@@ -262,7 +271,8 @@ describe('Pieces Exporter', function () {
     jobInfo = await apos.http.post('/api/v1/article/export?apikey=testKey', {
       body: {
         extension: 'csv',
-        batchSize: 10
+        batchSize: 10,
+        _ids: _ids1
       }
     });
 
@@ -278,11 +288,7 @@ describe('Pieces Exporter', function () {
       let job;
 
       try {
-        job = await apos.http.post('/api/v1/@apostrophecms/job/progress?apikey=testKey', {
-          body: {
-            _id: id
-          }
-        });
+        job = await apos.http.get(`/api/v1/@apostrophecms/job/${id}?apikey=testKey`, {});
       } catch (error) {
         assert(!error);
         return null;


### PR DESCRIPTION
- To test you will need to use the `PRO-2224-job-noti` branch of Apostrophe core and link that up locally. In addition to job notifications it includes temporary code to create a button that starts the export.
- There is an `export` branch of the testbed project with the proper option set on a piece type.

⚠️ The final test will fail until it is using the PRO-2224-job-noti branch of core.