### PR TITLE
PRO-2340 Renames methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Renames methods to decrease potential for conflicts with other modules.
+
 ## 1.0.0-beta
 
 * Initial release. Adds exporter features to pieces in Apostrophe 3 projects when configured.

--- a/lib/export.js
+++ b/lib/export.js
@@ -3,14 +3,14 @@ const path = require('path');
 
 module.exports = (self) => {
   return {
-    cleanup(file) {
+    exportCleanup(file) {
       try {
         fs.unlinkSync(file);
       } catch (e) {
         self.apos.util.error(e);
       }
     },
-    async writeBatch (req, out, _ids, lastId = '', reporting, options) {
+    async exportWriteBatch (req, out, _ids, lastId = '', reporting, options) {
       let batch;
 
       try {
@@ -102,7 +102,7 @@ module.exports = (self) => {
         out.on('error', function (err) {
           if (!reported) {
             reported = true;
-            self.cleanup(filepath);
+            self.exportCleanup(filepath);
             self.apos.util.error(err);
 
             return reject(self.apos.error('error'));
@@ -122,7 +122,7 @@ module.exports = (self) => {
             try {
               await copyIn(filepath, downloadPath);
             } catch (error) {
-              self.cleanup(filepath);
+              self.exportCleanup(filepath);
               return reject(error);
             }
 
@@ -148,7 +148,7 @@ module.exports = (self) => {
               }
             });
 
-            self.cleanup(filepath);
+            self.exportCleanup(filepath);
 
             const expiration = self.options.export && self.options.export.expiration;
 
@@ -172,12 +172,12 @@ module.exports = (self) => {
       const pubReq = req.clone({ mode: 'published' });
 
       do {
-        lastId = await self.writeBatch(pubReq, out, _ids, lastId, reporting, {
+        lastId = await self.exportWriteBatch(pubReq, out, _ids, lastId, reporting, {
           ...options
         });
       } while (lastId);
 
-      self.close(out);
+      self.closeExportStream(out);
 
       return result;
     },
@@ -224,7 +224,7 @@ module.exports = (self) => {
 
       return record;
     },
-    close(stream) {
+    closeExportStream(stream) {
       stream.end();
     },
     beforeExport (req, piece, record) {


### PR DESCRIPTION
This renames export methods so they are not likely to conflict with project-level code or other module code. This is a risk since the exporter module "improves" piece type modules.