### PR TITLE
add csv to label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Change label to "Export as CSV" to avoid confusion with the new [`@apostrophecms/import-export`](https://github.com/apostrophecms/import-export) module.
+
 ## 1.0.0 - 2023-01-16
 
 * Declared stable after many quiet moons of no code changes.

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
     return {
       add: {
         export: {
-          label: 'Export',
+          label: 'Export as CSV',
           route: '/export',
           messages: {
             progress: 'Exporting {{ type }}...'


### PR DESCRIPTION
## Summary

Related to https://github.com/apostrophecms/import-export/pull/50

Change the label to avoid confusion with the new `@apostrophecms/import-export` module:

![image](https://github.com/apostrophecms/piece-type-exporter/assets/8301962/e1bdf7df-73f5-427b-adbf-ca1e57aa69da)

Note that we cannot add several button in the same 3-vertical-dots menu, but that's not in the scope of this PR.